### PR TITLE
Add battery monitor design notes

### DIFF
--- a/battery_monitor/DESIGN.md
+++ b/battery_monitor/DESIGN.md
@@ -1,0 +1,311 @@
+# Battery monitor design
+
+## Status
+
+This document records requirements and design decisions for a reusable, ultra-low-power battery monitor intended for vehicles and small engine equipment. The first target is a 1971 Chevelle, but the hardware should also work on motorcycles, generators, lawn equipment, and similar 12 V systems.
+
+The board is still in the design phase. Electrical values and part choices below are provisional until we validate them against datasheets, bench measurements, and automotive transient tests.
+
+## Goals
+
+The monitor should:
+
+- run for months or years from an attached 12 V battery without becoming a meaningful parasitic load
+- measure battery voltage and temperature while the equipment is parked
+- wake immediately when useful vehicle-state inputs change
+- advertise state over Bluetooth Low Energy so existing ESPHome Bluetooth proxies can forward it to Home Assistant
+- support different battery chemistries without putting chemistry-specific state-of-charge rules into embedded firmware
+- tolerate an older automotive electrical environment with ignition noise, relays, motors, alternator events, reverse polarity, and load-dump-style transients
+- leave room on the PCB for a future remote-start trigger output
+
+## Current targets
+
+### Power budget
+
+The design target is less than 25 uA average battery-side current while parked. Roughly 15-20 uA is preferred.
+
+This matters for very small batteries. A 3 Ah powersports battery loses about 0.13 Ah per year to a constant 15 uA load and about 0.22 Ah per year to 25 uA, before accounting for the battery's own self-discharge.
+
+The finished PCB must be measured rather than trusted from a spreadsheet. Development boards are not representative because LEDs, USB interfaces, regulators, and pullups can dominate the sleep budget.
+
+### Reporting cadence
+
+The firmware should use an adaptive cadence rather than one fixed interval.
+
+Initial behavior:
+
+1. Freshly active or recently charged: sample about every 15 minutes when voltage is stable.
+2. Significant voltage change: enter an active-monitoring mode and sample about every 30 seconds.
+3. Charging or another sustained electrical event: slow to roughly 2-5 minute samples after the voltage slope becomes small.
+4. Long inactivity: if no charging event has been detected for about three months, increase the normal interval to roughly 30 minutes.
+5. Low-voltage conservation: if battery voltage has fallen substantially, increase the interval to roughly 2 hours or more so the monitor does not materially accelerate discharge.
+6. Input transitions: door, ignition, parking-light, and other wake-capable input transitions should cause an immediate measurement and advertisement.
+
+Exact thresholds are firmware policy and will be tuned from real traces. The PCB should not encode charger or chemistry thresholds in hardware.
+
+The device should retain enough state across sleep to know how long it has been since charging was detected and which cadence tier applies. Flash writes should be minimized; elapsed time can normally be accumulated in retained RAM and checkpointed infrequently if needed.
+
+## Home Assistant responsibilities
+
+The node reports facts. Home Assistant interprets them.
+
+The node should report at least:
+
+- battery voltage
+- module/interior temperature
+- optional external battery temperature
+- door/courtesy state
+- ignition state
+- parking-light state
+- spare automotive input state
+- remote-start-enable switch state
+- wake reason or equivalent diagnostic state where practical
+
+Home Assistant should own:
+
+- battery chemistry
+- battery-capacity metadata
+- state-of-charge estimation
+- low and critical voltage thresholds
+- charging-state inference
+- long-term voltage trends
+- alerts such as lights on with ignition off
+- reminders to connect a charger
+
+This keeps the board reusable across AGM, flooded lead-acid, LiFePO4, and other battery types.
+
+## Radio and firmware
+
+The preferred radio family is Nordic nRF52, currently nRF52840.
+
+The production PCB should use a pre-certified module with an integrated RF section rather than laying out the radio from the bare SoC. A Raytac MDBT50Q-class module is a leading candidate.
+
+Normal telemetry should use connectionless BLE advertisements. BTHome is the preferred payload format because Home Assistant and ESPHome Bluetooth proxies already understand it.
+
+The normal sequence should be:
+
+1. wake from RTC or GPIO sense
+2. read digital inputs
+3. measure voltage and enabled temperature channels
+4. update the cadence state machine
+5. advertise the current state several times for reception reliability
+6. return to low-power sleep
+
+The device should not maintain a BLE connection during ordinary operation.
+
+ESPHome on nRF52 remains interesting, but it is not a hard requirement. A small Zephyr or C/C++ firmware is acceptable if it produces materially lower power or a cleaner BTHome implementation.
+
+## Inputs
+
+The current PCB requirement is:
+
+- IN1: ignition
+- IN2: door/courtesy
+- IN3: parking lights
+- IN4: spare protected automotive input
+- local input: remote-start-enable switch sense
+- ADC: battery voltage
+- ADC: onboard temperature sensor
+- ADC: optional external battery thermistor
+
+All automotive digital inputs should be able to wake the MCU on either logical transition.
+
+### Parking lights
+
+Parking-light state is explicitly required so Home Assistant can detect cases such as lights left on while ignition is off.
+
+The embedded node reports only the light and ignition states. Alert timing and policy belong in Home Assistant.
+
+### Remote-start enable switch
+
+The future remote-start output only needs to emulate a momentary ground signal into the AUX trigger of an existing commercial Directed Electronics remote-start system.
+
+The remote starter already provides its own park, brake, hood, over-rev, and other starting interlocks.
+
+The board should still use a physical series disconnect in the AUX trigger wire. A DPDT switch is preferred:
+
+- one pole physically disconnects the trigger path
+- the second pole reports whether remote start is enabled or disabled
+
+The MCU indication is informational. The physical disconnect remains effective even if the MCU or firmware fails.
+
+## Future output
+
+Reserve PCB resources for one protected low-side/open-drain output capable of pulling the remote-start AUX input to ground for a configured pulse.
+
+The output stage should be unpopulated or otherwise inactive in the first hardware revision unless we explicitly decide to implement it.
+
+Before selecting that driver, measure or verify the Directed AUX input voltage, current, and trigger timing requirements.
+
+## Temperature
+
+Provide two temperature channels:
+
+1. onboard sensor for module/interior temperature
+2. optional external thermistor for battery temperature
+
+A switched NTC divider is attractive because the MCU can power it only during a measurement. This keeps sleep current negligible.
+
+The external thermistor is optional on equipment where battery-temperature compensation is not useful.
+
+## Battery voltage measurement
+
+The current preference is a permanently connected very-high-value divider rather than a switched divider.
+
+Reasons:
+
+- fewer leakage paths and switching components
+- no divider-settling delay after wake
+- no charge injection from a switch
+- the current can be held to only a few microamps with megaohm-range resistors
+
+The divider must be selected alongside the nRF52840 SAADC acquisition-time limits. The ADC node should include capacitance and low-leakage protection so automotive transients do not reach the MCU pin.
+
+Use multiple series resistors in the upper divider leg so one small resistor does not see the full transient voltage.
+
+Calibrate battery-voltage measurements in firmware against a known-good DMM. Do not assume resistor tolerance and ADC gain error alone will meet the desired absolute accuracy.
+
+## Automotive digital-input concept
+
+The current preference is protected nanopower comparator inputs rather than optocouplers.
+
+Reasons:
+
+- the monitor already shares chassis ground with the vehicle
+- some vehicle inputs may remain at 12 V for months, so optocoupler LED current could become a meaningful parked load
+- a megaohm-range divider can make the high-state current well below 1 uA
+- a comparator gives a clean logic level and predictable threshold without optocoupler CTR variation
+
+A TLV3702-Q1-class dual nanopower comparator is a leading candidate. Two dual packages can service four automotive inputs.
+
+A representative channel is:
+
+```text
+vehicle input
+    |
+ high-value series/divider network
+    |
+    +---- low-leakage clamp / RC filter ---- comparator +
+                                              comparator - ---- shared reference
+                                                     |
+                                                     +---- nRF GPIO SENSE
+```
+
+The threshold should be comfortably above ground noise and comfortably below a valid 12 V state. Roughly 5 V vehicle-side is a reasonable starting point, but the final value must come from the complete divider, hysteresis, leakage, and transient design.
+
+Each channel should tolerate automotive input transients without relying on the MCU's internal ESD diodes.
+
+## Power and protection
+
+The intended power path is:
+
+```text
+BAT+ ---- fuse ----+---- reverse-polarity element ---- low-Iq 3.3 V regulator ---- 3V3
+                   |
+                   +---- high-energy automotive TVS ---- chassis ground
+```
+
+The TVS belongs before a small series reverse-polarity diode so load-dump surge current returns directly to chassis instead of flowing through the diode.
+
+The current regulator candidate is TPS7A16-Q1 because it combines low quiescent current with a 60 V input rating. This is attractive for an nRF52 load because short BLE transmit bursts do not dissipate enough power to make an LDO unreasonable.
+
+A high-voltage automotive buck regulator remains an alternative if later loads make the LDO unattractive.
+
+The protection design must consider:
+
+- normal battery range
+- alternator charging voltage
+- cranking brownout
+- reverse battery
+- jump-start conditions
+- relay and motor transients
+- positive load-dump-style events
+- negative ISO 7637-style pulses
+- EMI from ignition, electric fans, fuel pump, injectors, and a capacitive-discharge ignition system
+
+A TVS alone is not proof of automotive robustness. We still need proper source impedance, capacitors, layout, component voltage ratings, and bench testing.
+
+## Preliminary always-on current budget
+
+These are planning numbers, not measured results.
+
+| Load | Approximate target |
+| --- | ---: |
+| nRF52840 low-power sleep with RTC / retained state | 2-4 uA |
+| 60 V low-Iq LDO | about 5 uA |
+| four nanopower comparator channels | about 2-3 uA |
+| battery-voltage divider | about 1.5-2 uA |
+| comparator reference and miscellaneous leakage | about 1-3 uA |
+| total design target | roughly 15-20 uA |
+| maximum parked target | 25 uA |
+
+BLE wake energy is expected to add little to the average current at 15-minute or slower intervals, but we will measure the complete wake/measure/advertise cycle on real hardware.
+
+## Low-battery self-preservation
+
+The monitor should reduce its own contribution to discharge as a battery remains unused.
+
+The first policy to prototype is:
+
+```text
+normal, recently active
+    -> 15 minute reports
+
+no charger detected for ~3 months
+    -> 30 minute reports
+
+battery voltage has declined substantially
+    -> 2 hour reports
+
+battery becomes deeply discharged
+    -> very sparse reports, while retaining GPIO wake capability where safe
+```
+
+This policy is intentionally separate from battery-health classification. We should prefer relative decline and configurable absolute guardrails so a reusable board is not silently assuming AGM thresholds.
+
+Home Assistant should alert well before the firmware reaches its deepest conservation tier.
+
+## Schematic work order
+
+The schematic should be developed and reviewed in this order:
+
+1. battery input, fuse assumptions, TVS, reverse-polarity protection, regulator, and decoupling
+2. one complete protected automotive comparator input with hysteresis and wake behavior
+3. replicate the verified input channel for ignition, door, parking lights, and AUX
+4. battery-voltage ADC network and clamps
+5. onboard and external temperature channels
+6. nRF52840 module, SWD/programming interface, reset, crystals if required by the selected module, and RF keepout
+7. remote-start-enable sense input
+8. reserved remote-start low-side output
+9. connectors, test points, mechanical mounting, and enclosure constraints
+
+## Planned repository layout
+
+```text
+battery_monitor/
+    DESIGN.md
+    hardware/
+        battery_monitor.kicad_pro
+        battery_monitor.kicad_sch
+        battery_monitor.kicad_pcb
+    firmware/
+    enclosure/
+        battery_monitor.scad
+```
+
+The KiCad and OpenSCAD files will be added after the electrical interfaces and board dimensions settle enough that generating them is useful.
+
+## Open decisions
+
+- exact nRF52840 module and footprint
+- exact TVS and reverse-polarity components
+- regulator package and thermal/layout details
+- comparator input resistor values, clamps, hysteresis, and filtering
+- divider ratio and ADC protection values
+- onboard temperature sensor type
+- external thermistor value and connector
+- firmware framework: ESPHome/Zephyr versus small custom firmware
+- BTHome object mapping for ignition, parking lights, AUX, and diagnostics
+- low-battery conservation thresholds
+- enclosure connector style and environmental sealing
+- final remote-start output component after AUX input characterization

--- a/battery_monitor/firmware/README.md
+++ b/battery_monitor/firmware/README.md
@@ -1,0 +1,62 @@
+# Battery monitor firmware
+
+The firmware is split into a platform-independent policy layer and a future nRF52840 hardware layer.
+
+The policy layer exists now because the storage cadence is easy to get subtly wrong and does not depend on Zephyr, ESPHome, BLE, or Nordic hardware. We can test it with a normal C++ compiler before choosing the final embedded framework.
+
+## Current behavior
+
+`update_policy()` consumes elapsed time, battery voltage, and ignition state. It returns the next sampling interval and the current cadence mode.
+
+The default policy is:
+
+- stable/recently active: 15 minutes
+- newly detected charger activity: 30 seconds for 10 minutes
+- continuing voltage movement after fast mode: 2 minutes, for up to an hour
+- no detected charger for about 90 days: 30 minutes
+- substantial decline from the highest observed charged reference: 2 hours
+- deeper decline: 12 hours
+
+The low-battery tiers are based on voltage drop from a learned reference rather than AGM-specific absolute voltages. Optional absolute emergency thresholds are available in `PolicyConfig`, but default to disabled. Battery-health interpretation still belongs in Home Assistant.
+
+A large voltage rise is considered a new external-charging session only while ignition is off and only when the device is not already inside the existing charge session's fast/settling window. This prevents a rising charger curve from repeatedly resetting fast mode.
+
+## What the policy does not own
+
+The platform layer still needs to provide:
+
+- RTC/monotonic time
+- battery ADC measurement and calibration
+- ignition, door, parking-light, AUX, and remote-enable inputs
+- onboard and external temperature readings
+- wake-reason tracking
+- BTHome advertisement encoding
+- GPIO `SENSE` wake setup
+- retained-state and occasional nonvolatile checkpointing
+- actual sleep entry
+
+Door and light changes should still cause immediate wake/report behavior even when the battery cadence has backed off to hours. The cadence policy controls periodic sampling; it does not suppress hardware wake inputs.
+
+## Host test
+
+The policy currently builds as C++17 with no external dependencies:
+
+```sh
+g++ -std=c++17 -Wall -Wextra -Werror \
+  -Iinclude src/policy.cpp tests/policy_test.cpp \
+  -o /tmp/battery-monitor-policy-test
+
+/tmp/battery-monitor-policy-test
+```
+
+Expected output:
+
+```text
+policy tests passed
+```
+
+The test covers normal cadence, charger detection, fast and settling modes, 90-day idle backoff, low/deep conservation, and the rule that an alternator voltage rise with ignition on is not an external-charger event.
+
+## Next firmware step
+
+Keep the policy API small while the hardware schematic settles. The next embedded work should be a thin nRF52840 platform layer that can wake, collect one observation, encode one BTHome advertisement, and sleep. Do not add a persistent BLE connection to the normal measurement path.

--- a/battery_monitor/firmware/include/battery_monitor/policy.hpp
+++ b/battery_monitor/firmware/include/battery_monitor/policy.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <cstdint>
+
+namespace battery_monitor {
+
+struct PolicyConfig {
+  uint32_t normal_interval_s = 15 * 60;
+  uint32_t long_idle_interval_s = 30 * 60;
+  uint32_t fast_interval_s = 30;
+  uint32_t settling_interval_s = 2 * 60;
+  uint32_t low_interval_s = 2 * 60 * 60;
+  uint32_t deep_interval_s = 12 * 60 * 60;
+
+  uint64_t long_idle_after_s = 90ULL * 24 * 60 * 60;
+  uint32_t fast_mode_for_s = 10 * 60;
+  uint32_t settling_mode_for_s = 60 * 60;
+
+  int32_t charger_rise_mv = 150;
+  int32_t stable_delta_mv = 25;
+
+  // Chemistry-neutral relative conservation thresholds. These are measured
+  // from the highest credible resting voltage observed after charging.
+  int32_t low_drop_from_reference_mv = 700;
+  int32_t deep_drop_from_reference_mv = 1200;
+
+  // Optional absolute emergency guardrails. Zero disables them. A board
+  // profile may set these when the battery chemistry is known locally.
+  int32_t low_absolute_mv = 0;
+  int32_t deep_absolute_mv = 0;
+};
+
+enum class CadenceMode {
+  Normal,
+  FastActivity,
+  Settling,
+  LongIdle,
+  LowConservation,
+  DeepConservation,
+};
+
+struct Observation {
+  uint64_t monotonic_s = 0;
+  int32_t voltage_mv = 0;
+  bool ignition_on = false;
+};
+
+struct PolicyState {
+  bool initialized = false;
+  int32_t previous_voltage_mv = 0;
+  int32_t reference_voltage_mv = 0;
+  uint64_t last_charge_s = 0;
+  uint64_t fast_until_s = 0;
+  uint64_t settling_until_s = 0;
+};
+
+struct PolicyDecision {
+  CadenceMode mode = CadenceMode::Normal;
+  uint32_t next_interval_s = 15 * 60;
+  bool charger_detected = false;
+  bool significant_voltage_change = false;
+};
+
+PolicyDecision update_policy(const PolicyConfig& config,
+                             PolicyState& state,
+                             const Observation& observation);
+
+}  // namespace battery_monitor

--- a/battery_monitor/firmware/src/policy.cpp
+++ b/battery_monitor/firmware/src/policy.cpp
@@ -1,0 +1,94 @@
+#include "battery_monitor/policy.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+
+namespace battery_monitor {
+namespace {
+
+bool below_optional_threshold(int32_t voltage_mv, int32_t threshold_mv) {
+  return threshold_mv > 0 && voltage_mv <= threshold_mv;
+}
+
+}  // namespace
+
+PolicyDecision update_policy(const PolicyConfig& config,
+                             PolicyState& state,
+                             const Observation& observation) {
+  PolicyDecision decision;
+
+  if (!state.initialized) {
+    state.initialized = true;
+    state.previous_voltage_mv = observation.voltage_mv;
+    state.reference_voltage_mv = observation.voltage_mv;
+    state.last_charge_s = observation.monotonic_s;
+    decision.next_interval_s = config.normal_interval_s;
+    return decision;
+  }
+
+  const int32_t delta_mv = observation.voltage_mv - state.previous_voltage_mv;
+  decision.significant_voltage_change =
+      std::abs(delta_mv) >= config.charger_rise_mv;
+
+  // A charger is inferred only while ignition is off. A large rise while the
+  // engine is running is alternator activity, not evidence of an external
+  // charger being attached during storage.
+  const bool new_charge_session =
+      !observation.ignition_on &&
+      delta_mv >= config.charger_rise_mv &&
+      observation.monotonic_s >= state.settling_until_s;
+  if (new_charge_session) {
+    decision.charger_detected = true;
+    state.last_charge_s = observation.monotonic_s;
+    state.fast_until_s = observation.monotonic_s + config.fast_mode_for_s;
+    state.settling_until_s =
+        state.fast_until_s + config.settling_mode_for_s;
+  }
+
+  // Once external charging has been observed, allow the resting-voltage
+  // reference to move upward. Never lower it merely because the battery has
+  // discharged; that would defeat relative low-voltage conservation.
+  if (decision.charger_detected ||
+      observation.voltage_mv > state.reference_voltage_mv) {
+    state.reference_voltage_mv = observation.voltage_mv;
+  }
+
+  const int32_t drop_from_reference_mv =
+      state.reference_voltage_mv - observation.voltage_mv;
+  const bool deep =
+      drop_from_reference_mv >= config.deep_drop_from_reference_mv ||
+      below_optional_threshold(observation.voltage_mv,
+                               config.deep_absolute_mv);
+  const bool low =
+      drop_from_reference_mv >= config.low_drop_from_reference_mv ||
+      below_optional_threshold(observation.voltage_mv,
+                               config.low_absolute_mv);
+
+  if (!observation.ignition_on && deep) {
+    decision.mode = CadenceMode::DeepConservation;
+    decision.next_interval_s = config.deep_interval_s;
+  } else if (!observation.ignition_on && low) {
+    decision.mode = CadenceMode::LowConservation;
+    decision.next_interval_s = config.low_interval_s;
+  } else if (observation.monotonic_s < state.fast_until_s) {
+    decision.mode = CadenceMode::FastActivity;
+    decision.next_interval_s = config.fast_interval_s;
+  } else if (observation.monotonic_s < state.settling_until_s &&
+             std::abs(delta_mv) > config.stable_delta_mv) {
+    decision.mode = CadenceMode::Settling;
+    decision.next_interval_s = config.settling_interval_s;
+  } else if (!observation.ignition_on &&
+             observation.monotonic_s - state.last_charge_s >=
+                 config.long_idle_after_s) {
+    decision.mode = CadenceMode::LongIdle;
+    decision.next_interval_s = config.long_idle_interval_s;
+  } else {
+    decision.mode = CadenceMode::Normal;
+    decision.next_interval_s = config.normal_interval_s;
+  }
+
+  state.previous_voltage_mv = observation.voltage_mv;
+  return decision;
+}
+
+}  // namespace battery_monitor

--- a/battery_monitor/firmware/tests/policy_test.cpp
+++ b/battery_monitor/firmware/tests/policy_test.cpp
@@ -1,0 +1,63 @@
+#include "battery_monitor/policy.hpp"
+
+#include <cassert>
+#include <iostream>
+
+using battery_monitor::CadenceMode;
+using battery_monitor::Observation;
+using battery_monitor::PolicyConfig;
+using battery_monitor::PolicyState;
+using battery_monitor::update_policy;
+
+static constexpr uint64_t day = 24ULL * 60 * 60;
+
+int main() {
+  PolicyConfig cfg;
+  PolicyState state;
+
+  auto d = update_policy(cfg, state, Observation{0, 12600, false});
+  assert(d.mode == CadenceMode::Normal);
+  assert(d.next_interval_s == 900);
+
+  d = update_policy(cfg, state, Observation{900, 12610, false});
+  assert(d.mode == CadenceMode::Normal);
+  assert(!d.charger_detected);
+
+  // External charger attachment: 390 mV rise with ignition off.
+  d = update_policy(cfg, state, Observation{1800, 13000, false});
+  assert(d.charger_detected);
+  assert(d.mode == CadenceMode::FastActivity);
+  assert(d.next_interval_s == 30);
+
+  // Voltage continues climbing, then transitions to settling cadence.
+  d = update_policy(cfg, state, Observation{1800 + 11 * 60, 13500, false});
+  assert(d.mode == CadenceMode::Settling);
+  assert(d.next_interval_s == 120);
+
+  // Stable charger voltage no longer needs medium-rate samples forever.
+  d = update_policy(cfg, state, Observation{1800 + 12 * 60, 13510, false});
+  assert(d.mode == CadenceMode::Normal);
+
+  // A 90-day lack of charging backs off normal monitoring.
+  d = update_policy(cfg, state, Observation{1800 + 91 * day, 13490, false});
+  assert(d.mode == CadenceMode::LongIdle);
+  assert(d.next_interval_s == 1800);
+
+  // Relative decline from the observed charged reference enters conservation.
+  d = update_policy(cfg, state, Observation{1800 + 92 * day, 12750, false});
+  assert(d.mode == CadenceMode::LowConservation);
+  assert(d.next_interval_s == 7200);
+
+  d = update_policy(cfg, state, Observation{1800 + 93 * day, 12200, false});
+  assert(d.mode == CadenceMode::DeepConservation);
+  assert(d.next_interval_s == 43200);
+
+  // Alternator rise must not reset the external-charger timer.
+  PolicyState vehicle_state;
+  update_policy(cfg, vehicle_state, Observation{0, 12400, false});
+  d = update_policy(cfg, vehicle_state, Observation{900, 14200, true});
+  assert(!d.charger_detected);
+
+  std::cout << "policy tests passed\n";
+  return 0;
+}

--- a/battery_monitor/hardware/FRONT_END_ANALYSIS.md
+++ b/battery_monitor/hardware/FRONT_END_ANALYSIS.md
@@ -1,0 +1,262 @@
+# Front-end component decisions
+
+This note records the component and tolerance work behind the first prototype schematic. These are prototype choices, not a claim that the finished board meets an automotive transient standard. We still have to test the assembled board.
+
+## Decisions in this pass
+
+For the first KiCad revision, use these parts and values unless later analysis finds a concrete problem:
+
+| Function | Prototype choice | Status |
+| --- | --- | --- |
+| Load-dump TVS | ST SM50T30CAY | freeze for prototype |
+| Reverse-battery diode | ST STTH1R02-Y | freeze for prototype |
+| 3.3 V regulator | TI TPS7A1633A-Q1 / TPS7A16A-Q1 family | freeze for prototype |
+| Four vehicle-input comparators | TI TLV7034-Q1 | freeze for prototype |
+| Vehicle-input upper divider | 4.7 M + 4.7 M, 1% | freeze for prototype |
+| Vehicle-input lower divider | 1.5 M, 1% | freeze for prototype |
+| Vehicle-input feedback | 33 M, 1% | freeze for prototype |
+| Vehicle-input filter | 4.7 nF | freeze for prototype |
+| Shared comparator reference | 3.9 M / 1.0 M with 100 nF | freeze for prototype |
+| Low-leakage signal clamps | Nexperia BAV199-Q family | provisional; verify exact package pinout |
+| Remote-start enable sense pullup | 4.7 M external | freeze for prototype |
+
+The battery ADC divider remains provisional until the nRF52840 SAADC source-impedance assumptions are checked one more time against the exact firmware configuration.
+
+## Power-input protection
+
+The power connector enters a deliberately noisy part of the board:
+
+```text
+                 raw vehicle side
+
+BAT+ -- fuse --+---------------- TVS ---------------- GND
+               |
+               +-- reverse diode -- 100 R -- protected VIN -- LDO -- 3V3
+                                      |
+                                  input bulk C
+```
+
+The TVS is before the small series reverse-polarity diode. A load-dump pulse can put a large current through the TVS, and that current should return directly to the harness ground entry rather than pass through the diode or the logic-side ground path.
+
+### TVS selection
+
+Use **SM50T30CAY** for the first prototype.
+
+The ST SM50TxxCAY family is a bidirectional, automotive 5 kW TVS family in an SMC package. For SM50T30AY/CAY, the current datasheet specifies:
+
+- 26 V maximum reverse working voltage (`VRM`)
+- 28.9 V minimum breakdown voltage
+- 42.1 V maximum clamp at 119 A for a 10/1000 us pulse at 25 C
+- 0.2 uA maximum reverse leakage at `VRM` and 25 C
+- 1 uA maximum reverse leakage at `VRM` and 85 C
+
+The 26 V working voltage is intentional. This board is for nominal 12 V systems; it should tolerate a 24 V jump-start condition, but it is not a 24 V vehicle monitor. Using a lower stand-off voltage buys useful clamp margin for the 60 V regulator.
+
+ST specifies a positive temperature coefficient for this part. Applying the datasheet formula to the 42.1 V 10/1000 us clamp gives roughly 46.2 V at 125 C and 48.2 V at 175 C. That leaves much more margin below the regulator's 60 V input limit than the 30 V-working-voltage part we considered first.
+
+The short 8/20 us rating is a different and substantially higher-current condition. We are not assuming the TVS alone holds every possible fast pulse below the regulator rating. The reverse diode, 100 ohm series resistor, local capacitance, physical wiring impedance, and layout are part of the protection network, and the complete assembly needs transient testing.
+
+A Bourns SM8S30CA-Q-class part remains a higher-energy alternative if testing shows the 5 kW SMC part is too small. Its package and guaranteed leakage are less attractive for this unusually low-current design.
+
+### Reverse-battery diode
+
+Use **STTH1R02-Y** for the first prototype.
+
+It is a 200 V, 1 A automotive diode in SOD123Flat. ST explicitly identifies reverse-battery protection as an intended automotive use. A series diode is deliberately unsophisticated here: the monitor normally uses microamps, so saving a few hundred millivolts with an ideal-diode controller is not worth another always-on circuit.
+
+The bidirectional TVS is important with this topology. During reverse battery, it does not intentionally short the input and depend on the fuse opening. D2 blocks the downstream electronics instead.
+
+### 3.3 V regulator
+
+Use the fixed 3.3 V member of the **TPS7A16A-Q1** family for the prototype.
+
+The part accepts 3-60 V and its typical ground current is 5 uA at a 10 uA load. The electrical-characteristics table allows up to 15 uA, so the 25 uA board target is a **measured acceptance target**, not something we can prove by adding every datasheet maximum.
+
+That distinction matters. Typical component values predict a comfortable result, but high-temperature leakage and part-to-part spread can consume more of the budget. We should measure several assembled boards if this design gets duplicated across equipment.
+
+Keep the fixed-output part so there is no feedback divider wasting current.
+
+## Vehicle digital inputs
+
+Use one **TLV7034-Q1** quad push-pull comparator instead of two TLV3702-Q1 dual comparators.
+
+Reasons:
+
+- four channels in one package
+- 315 nA/channel typical quiescent current
+- 2 pA maximum input bias on TI's product data
+- 8 mV maximum input offset at 25 C
+- built-in hysteresis and power-on reset
+- push-pull output, so no output pullup current is required
+- automotive qualification
+
+The lower input bias is particularly valuable because the vehicle dividers intentionally use megaohm resistors.
+
+### Shared threshold reference
+
+Use:
+
+```text
+3V3 -- 3.9 M --+-- VREF
+                |
+              1.0 M
+                |
+               GND
+
+VREF -- 100 nF -- GND
+```
+
+Nominal `VREF` is about 0.673 V. The divider costs about 0.67 uA continuously.
+
+We could make this divider ten times larger, but saving roughly 0.6 uA would make the common reference much more sensitive to contamination and leakage. The current value is a better tradeoff for a board that may live in a vehicle for years.
+
+### One vehicle input channel
+
+Use this network for IGN, DOOR, PARK_LIGHTS, and AUX_IN:
+
+```text
+VEH_IN -- 4.7 M -- 4.7 M --+-- VIN_SENSE --> TLV7034 +
+                            |
+                           1.5 M
+                            |
+                           GND
+
+VIN_SENSE -- 4.7 nF -- GND
+
+TLV7034 - ---------------- VREF
+
+TLV7034 OUT -------------- MCU GPIO/SENSE
+      |
+      +------ 33 M ------- VIN_SENSE
+```
+
+Add a low-leakage clamp network at `VIN_SENSE`. BAV199-Q is the current family choice; verify the exact package pinout before the KiCad symbol is considered final.
+
+Split the 9.4 M upper leg into two 4.7 M resistors. This shares transient voltage between packages and gives us more freedom when checking resistor working-voltage and pulse ratings.
+
+### Why the divider changed
+
+An earlier version used 11 M + 11 M over 3.3 M. It saved roughly half a microamp when a vehicle input was high, but it made a real PCB uncomfortably sensitive to nanoamp-scale leakage.
+
+The revised 9.4 M / 1.5 M divider uses approximately:
+
+| Vehicle input | Divider/input current, approximate |
+| ---: | ---: |
+| 12.0 V | 1.1 uA |
+| 12.6 V | 1.15 uA |
+| 14.4 V | 1.3 uA |
+| 16.0 V | 1.45 uA |
+
+An input that is low does not incur this current from the vehicle line. Normally IGN, parking lights, and AUX are all low during long-term storage; the door/courtesy wiring is the input most likely to have vehicle-dependent polarity.
+
+### Nominal switching points
+
+Ignoring the comparator's small internal hysteresis for a moment, the external network switches at roughly:
+
+- rising: 5.1 V vehicle-side
+- falling: 4.1 V vehicle-side
+
+The 33 M positive-feedback resistor therefore provides about 1 V of vehicle-side hysteresis. That is intentional; none of these signals is an analog measurement. We want a clean answer in the presence of relay noise, old switch contacts, and wiring leakage.
+
+### Corner analysis
+
+A simple worst-case enumeration was run over:
+
+- all threshold resistors at +/-1%
+- 3.3 V rail at +/-2%
+- comparator input offset at +/-8 mV
+- a broad internal-hysteresis range
+- injected leakage at the sense node in both directions
+
+The resulting vehicle-side thresholds were:
+
+| Added sense-node leakage | Rising range | Falling range |
+| ---: | ---: | ---: |
+| 0 nA | 4.77-5.52 V | 3.75-4.45 V |
+| +/-5 nA | 4.73-5.57 V | 3.70-4.50 V |
+| +/-10 nA | 4.68-5.62 V | 3.66-4.55 V |
+| +/-20 nA | 4.59-5.71 V | 3.57-4.64 V |
+| +/-50 nA stress case | 4.31-6.00 V | 3.29-4.93 V |
+
+This is materially better than the earlier 22 M upper-divider version. The old circuit moved by roughly a volt at only tens of nanoamps of unwanted leakage.
+
+The practical consequence is that the revised circuit is much less dependent on a perfectly clean, perfectly dry PCB. We should still keep `VIN_SENSE` traces short, clean flux residue, and consider conformal coating for boards expected to see condensation.
+
+### Input filtering
+
+The 4.7 nF capacitor with the divider's roughly-megaohm Thevenin impedance gives filtering in the few-millisecond range. Use firmware debounce on top of that.
+
+Door and parking-light reporting does not need microsecond response. Avoid increasing the capacitor enough to make a physical input feel delayed.
+
+## Remote-start enable sense
+
+Use the second pole of the physical DPDT enable switch as a local logic input:
+
+```text
+3V3 -- 4.7 M --+-- MCU GPIO/SENSE
+                |
+             switch pole
+                |
+               GND
+```
+
+The 4.7 M external pullup costs about 0.7 uA only while that pole is closed. A 470 k or 1 M pullup would waste too much current for a switch that may remain in one position for months.
+
+This input only reports the switch position. The other DPDT pole remains the literal series disconnect in the future remote-start AUX-trigger wire.
+
+## Low-frequency clock provision
+
+Provision the PCB for an external 32.768 kHz crystal on the nRF52840 module's low-frequency crystal pins, subject to the final Raytac module pinout.
+
+The device sleeps for most of its life, and interval accuracy over months is useful for the long-storage cadence policy. The nRF52840 can run its RTC from the internal RC oscillator, but an external low-frequency crystal gives substantially better timing accuracy and avoids periodic RC calibration. We will make the crystal population choice after measuring the actual module/firmware sleep current.
+
+Retain only the RAM needed for cadence state. Keeping all nRF52840 RAM alive merely to preserve a few counters is unnecessary current. Firmware can checkpoint the few values that must survive a total power loss without writing flash every wake.
+
+## Updated parked-current estimate
+
+This is an expected-value budget for design work, not a guaranteed maximum:
+
+| Always-on item | Approximate current |
+| --- | ---: |
+| TPS7A16A-Q1 regulator | 5.0 uA typical |
+| nRF52840 System ON + RTC, minimal retained state | about 1.5-3.2 uA, configuration dependent |
+| TLV7034-Q1, four channels | about 1.26 uA typical |
+| shared comparator reference | 0.67 uA |
+| battery-voltage divider | about 1.7 uA at 12.6 V |
+| SM50T30CAY leakage | <=0.2 uA at its 26 V VRM and 25 C; expected lower at normal battery voltage |
+| one vehicle input held high | about 1.15 uA at 12.6 V |
+| remote-enable sense, if grounded | about 0.70 uA |
+
+A representative subtotal lands around 12-14 uA before miscellaneous leakage and the averaged wake/advertise energy. That leaves useful room under the 25 uA acceptance target.
+
+Do not turn that estimate into a guarantee. The LDO alone permits 15 uA ground current at its datasheet maximum, and leakage rises with temperature. The assembled-board measurement is the requirement.
+
+## Prototype acceptance criteria
+
+Before installing a board in a vehicle, measure at least:
+
+1. battery-side sleep current at 12.6 V with all four vehicle inputs low
+2. sleep current with each vehicle input high individually
+3. sleep current with all four inputs high
+4. sleep current with remote-start enable sense in both positions
+5. sleep current after warm soak if practical
+6. 3.3 V droop and battery-side current during BLE advertising
+7. comparator rising/falling thresholds on all four channels
+8. threshold behavior with injected noise on a vehicle input
+9. reverse-battery survival
+10. 24 V jump-start-style input operation
+11. brownout/recovery behavior during crank-like dips
+12. positive and negative transient tests within safe bench capability
+
+The board passes the parked-current requirement only if the measured battery-side current is below 25 uA in the defined normal parked state. Prefer 20 uA or less so temperature, aging, dirt, and unit-to-unit spread have room.
+
+## What remains before KiCad
+
+The front-end architecture is now stable enough to draw. The remaining checks before calling the schematic ready for PCB layout are:
+
+- re-check the nRF52840 SAADC source-impedance requirement and freeze the battery divider
+- verify BAV199-Q package/pinout and signal-clamp orientation
+- choose actual resistor series/footprints with enough working-voltage and pulse margin
+- choose the input and output capacitor parts, including DC-bias derating
+- select the exact Raytac module variant and copy its antenna keepout and low-frequency-crystal pins from the current module drawing
+- choose connector families and decide whether the enclosure needs meaningful moisture sealing

--- a/battery_monitor/hardware/PROTOTYPE_BOM.md
+++ b/battery_monitor/hardware/PROTOTYPE_BOM.md
@@ -1,0 +1,215 @@
+# Prototype BOM and electrical constraints
+
+This file is the working purchase list for the first electrical prototype. It exists so the schematic can use real orderable parts rather than family names.
+
+Parts marked **frozen** are the default for the first KiCad revision. We can still change them if the schematic review or bench work finds a problem.
+
+## Core parts
+
+| Ref group | Function | Part | Prototype status |
+| --- | --- | --- | --- |
+| U1 | 3.3 V regulator | TI TPS7A1633A-Q1 / fixed 3.3 V TPS7A16A-Q1 family member | frozen |
+| U2 | four automotive input comparators | TI TLV7034-Q1 | frozen |
+| U3 | BLE MCU module | Raytac MDBT50Q-1MV2 | frozen |
+| D1 | raw-bus load-dump TVS | ST SM50T30CAY | frozen |
+| D2 | reverse-battery series diode | ST STTH1R02-Y | frozen |
+| Dx | low-leakage analog clamps | Nexperia BAV199-Q family | provisional until exact package/symbol check |
+
+## Why MDBT50Q-1MV2
+
+Raytac still lists the MDBT50Q-1MV2 as a current nRF52840 module. It provides 1 MB flash, 256 KB RAM, 48 GPIO, a chip antenna, and the usual nRF52840 ADC/debug interfaces in a 10.5 x 15.5 mm module.
+
+The PCB-antenna `MDBT50Q-P1MV2` is also electrically suitable. Start with the chip-antenna version because it is compact and avoids extending a PCB antenna structure farther into the enclosure. Keep the PCB layout modular enough that changing to the `P1MV2` footprint variant is still possible if range testing favors it.
+
+The newer `MDBT50Q-1MEN` line adds APProtect. That feature is not useful enough on a hobby/serviceable device to justify making SWD recovery more complicated during early firmware work.
+
+Raytac's design material provides an external 32.768 kHz crystal option. Include the crystal and load-capacitor footprints in the schematic. Populate them in the first prototype unless sleep-current measurements give a reason not to.
+
+## Battery ADC
+
+Freeze the existing divider for the prototype:
+
+```text
+RAW_BAT -- 3.32 M -- 3.32 M --+-- VBAT_ADC -- nRF SAADC
+                               |
+                             806 k
+                               |
+                              GND
+
+VBAT_ADC -- 10 nF -- GND
+```
+
+Nominal values:
+
+- divider ratio: about 0.10825
+- current at 12.6 V: about 1.69 uA
+- ADC node at 14.4 V: about 1.56 V
+- ADC node at 30 V: about 3.25 V
+- source resistance seen by the ADC: about 719 kOhm
+
+The nRF52 SAADC supports a 40 us acquisition time for source resistance up to 800 kOhm. Firmware **must** configure the battery-voltage channel for the 40 us acquisition setting.
+
+The 10 nF capacitor is more than a noise filter. It supplies the ADC sample-and-hold charge locally, which makes this unusually high source impedance much less troublesome for a slowly changing battery voltage.
+
+Firmware should:
+
+1. enable and calibrate the SAADC only when a measurement is needed
+2. use the longest 40 us acquisition setting for the battery channel
+3. discard the first conversion after SAADC startup if bench measurements show a repeatable settling error
+4. take a small burst of samples and average them
+5. stop the SAADC completely after the measurement
+6. apply board-specific gain/offset calibration stored in nonvolatile settings
+
+Do not leave the SAADC idling between reports; its idle current would be large compared with the whole parked-current budget.
+
+## Automotive input channel
+
+Replicate this four times:
+
+```text
+VEH_IN -- 4.7 M -- 4.7 M --+-- SENSE -- TLV7034-Q1 +
+                            |
+                           1.5 M
+                            |
+                           GND
+
+SENSE -- 4.7 nF -- GND
+TLV7034-Q1 - -- VREF
+TLV7034-Q1 OUT -- nRF GPIO/SENSE
+TLV7034-Q1 OUT -- 33 M -- SENSE
+```
+
+Shared reference:
+
+```text
+3V3 -- 3.9 M --+-- VREF
+                |
+               1 M
+                |
+               GND
+
+VREF -- 100 nF -- GND
+```
+
+Use 1% resistors for the thresholds. The circuit is intentionally not a precision detector; the goal is a stable automotive LOW/HIGH decision with substantial noise margin.
+
+### Resistor footprints
+
+Do not automatically use tiny 0402 parts for the high-side resistors. Working-voltage and pulse ratings matter more than board area here.
+
+For `RAW_BAT`, `IGN`, `DOOR`, `PARK_LIGHTS`, and `AUX_IN` high-side chains, start the KiCad BOM with 0805 or 1206 high-value resistors from a series whose continuous working-voltage specification we have actually checked. Split high-voltage legs across two physical resistors even when one part's nominal resistance would be convenient.
+
+Keep high-impedance sense nodes physically short and away from the raw harness connector, TVS current path, SWD clocks, and RF antenna.
+
+## Power front end
+
+Prototype topology:
+
+```text
+BAT+ -- external fuse --+-- SM50T30CAY -- GND
+                        |
+                        +-- STTH1R02-Y -- 100 R -- VIN_PROTECTED -- TPS7A1633A-Q1 -- 3V3
+                                                |
+                                           2.2-4.7 uF
+                                                |
+                                               GND
+```
+
+The 100 ohm series resistor is still a prototype value. It loses about 0.5 V at a 5 mA radio load, which is harmless at normal battery voltage. Bench-test BLE bursts and crank-like supply dips before freezing it for a production PCB.
+
+Place a 100 nF ceramic directly at the LDO input and output pins in addition to the required bulk capacitors. Use capacitor voltage ratings that remain sensible after DC-bias derating.
+
+The TVS return gets its own short, wide path to the harness-side ground entry. Do not route a large transient current under or through the MCU/ADC ground region.
+
+## Temperature channels
+
+Use two 10 k NTC channels:
+
+- one onboard NTC, placed away from the regulator and radio module
+- one optional remote NTC near the battery
+
+Excite each divider only while measuring. A GPIO-driven 10 k top resistor is acceptable for the first prototype.
+
+Add a small series resistor and ESD protection to the remote sensor connector because that cable leaves the enclosure.
+
+The exact NTC part remains open. Choose a common beta curve and document the actual beta/reference-temperature values in firmware rather than assuming every 10 k NTC is interchangeable.
+
+## Remote-start provisions
+
+### Physical enable
+
+Use a DPDT switch:
+
+- pole A is wired directly in series with the remote-start AUX trigger path
+- pole B goes to the MCU as the enable-state indication
+
+Sense pole B with a 4.7 M pullup to 3.3 V. The local logic input does not replace the physical disconnect.
+
+### Future AUX trigger output
+
+Reserve footprints for:
+
+- one MCU output GPIO
+- gate/base resistor
+- gate/base pulldown
+- low-side N-MOSFET or transistor
+- optional clamp/ESD part at the connector
+- test point
+
+Leave the driver DNP until the Directed Electronics AUX input voltage/current is measured or verified. The output must remain off through MCU reset, SWD programming, brownout, and loss of MCU power.
+
+## Programming and debug
+
+Expose at least:
+
+- SWDIO
+- SWCLK
+- RESET
+- 3V3 reference
+- GND
+
+Use a small pogo/test-pad pattern rather than committing enclosure space to a permanent header. The first hand-built board may also carry through-hole pads or a Tag-Connect-compatible footprint if convenient.
+
+Add named test points for:
+
+- RAW_BAT
+- VIN_PROTECTED
+- 3V3
+- VREF
+- VBAT_ADC
+- all four comparator outputs
+- TEMP_BOARD_ADC
+- TEMP_BAT_ADC
+
+## Current-budget acceptance
+
+The target remains:
+
+- preferred normal parked current: <=20 uA battery-side
+- hard prototype acceptance target: <25 uA battery-side
+
+Measure that with the production-intent regulator, radio module, and input circuits. A development board result is not relevant because LEDs, debugger circuits, and board regulators change the answer.
+
+Also record current for these states so firmware/HA documentation can explain the real cost of each feature:
+
+- all vehicle inputs low
+- each input high separately
+- all inputs high
+- remote-start enable sense open and closed
+- 15-minute advertising cadence
+- 30-second active-monitoring cadence
+- deep-conservation cadence
+
+## Remaining part selections
+
+The schematic can now begin in KiCad. These choices can remain open while the first sheet is drawn:
+
+- exact BAV199-Q package for clamp networks
+- exact 32.768 kHz crystal and load capacitors
+- exact NTCs
+- connector family
+- high-value resistor manufacturer/series and footprints
+- bulk capacitor dielectric/package
+- future AUX-trigger transistor
+
+The next hardware review should focus on the actual KiCad power and analog sheets rather than another round of architecture discussion.

--- a/battery_monitor/hardware/README.md
+++ b/battery_monitor/hardware/README.md
@@ -1,0 +1,26 @@
+# Battery monitor hardware
+
+The hardware directory contains the prototype circuit decisions and the start of the KiCad project.
+
+Until the schematic has been opened, checked, and saved in KiCad, treat `tools/generate_schematic.py` as the reproducible source for the generated schematic. It uses only the Python standard library.
+
+From `battery_monitor/hardware/tools/`:
+
+```sh
+python3 generate_schematic.py
+```
+
+The script writes:
+
+```text
+battery_monitor.kicad_pro
+battery_monitor.kicad_sch
+```
+
+into `battery_monitor/hardware/`.
+
+The generated schematic includes the power/protection path, four automotive wake inputs, battery ADC divider, temperature channels, remote-start-enable sense input, and a logical nRF52840 module symbol. The future remote-start driver is deliberately not implemented yet.
+
+`VALIDATION.md` records what has and has not been checked. In particular, structural generation checks are not a substitute for opening the project in KiCad and running ERC.
+
+The electrical reasoning behind the component values lives in `FRONT_END_ANALYSIS.md`; `SCHEMATIC.md` is the readable circuit walkthrough; and `PROTOTYPE_BOM.md` is the purchase-oriented part list.

--- a/battery_monitor/hardware/SCHEMATIC.md
+++ b/battery_monitor/hardware/SCHEMATIC.md
@@ -1,0 +1,405 @@
+# Battery monitor schematic notes
+
+This file turns the high-level design into a first-pass circuit. It is not yet a release schematic. Values here are intended to be copied into KiCad after we review the electrical assumptions and choose footprints.
+
+## Sheet 1: battery input and 3.3 V supply
+
+The front end has four jobs: survive the vehicle, reject noise, prevent reverse-battery damage, and waste almost no current while parked.
+
+### Proposed topology
+
+```text
+                         vehicle harness
+
+BAT+ ---- external fuse ----+------------------------------+
+                            |                              |
+                            |                        D1 load-dump TVS
+                            |                              |
+                            +---- D2 reverse diode ---- R1 ----+---- U1 3.3 V LDO ---- 3V3
+                                                              |         |
+                                                             C1        C2
+                                                              |         |
+GND ----------------------------------------------------------+---------+---------------- GND
+```
+
+D1 is intentionally before D2. A load-dump TVS can carry far more current than the low-current reverse-polarity diode should ever see.
+
+A bidirectional TVS is preferred at this location. With a unidirectional TVS directly across the raw battery input, a reversed battery would forward-bias the TVS and turn reverse connection into an intentional fuse-blowing event. That is survivable if designed for it, but it is not the behavior we need here.
+
+### External fuse
+
+Require an inline fuse close to the battery connection. The monitor itself normally draws microamps and brief milliamp radio bursts, so a small fuse is sufficient electrically. The exact fuse value should also tolerate harness and connector realities; 0.5-1 A is a reasonable starting range.
+
+The PCB should not assume the vehicle fuse box protects a long added battery lead.
+
+### D1: load-dump TVS
+
+Requirements:
+
+- automotive/load-dump-rated part
+- bidirectional
+- roughly 30 V working standoff for a 12 V system
+- clamp voltage comfortably below the 60 V absolute input rating of U1
+- package and copper area capable of handling the specified pulse energy
+
+A Littelfuse SLD8S-class part remains the leading family, but the exact suffix is not locked until we confirm a bidirectional part and its clamp behavior from the current datasheet.
+
+The board layout matters as much as the part number. D1 should sit near the power connector with a short, wide return to the same ground entry region used by the harness.
+
+### D2: reverse-polarity diode
+
+The first revision should use a boring series diode rather than an ideal-diode controller.
+
+Candidate characteristics:
+
+- AEC-Q qualified where practical
+- at least 100 V reverse rating; 200 V is comfortable
+- at least several hundred milliamps forward capability despite the much smaller expected load
+- low leakage is useful but not critical in normal polarity because the diode is in series
+
+STTH1R02-Y is a current candidate. Its forward drop costs essentially nothing in this application because the load is tiny and the regulator has plenty of input-voltage headroom.
+
+### R1: supply isolation
+
+Start with 100 ohms in 1206 or a similarly pulse-tolerant package.
+
+R1 serves three purposes:
+
+- limits current into the downstream network during residual transients
+- isolates the LDO input capacitor from the vehicle harness
+- forms a useful low-pass filter with C1
+
+At a 5 mA BLE transmit load, 100 ohms drops about 0.5 V. That is harmless from a normal 12 V battery. We should verify cold-cranking behavior with the finished load before freezing the value.
+
+### C1: protected input bulk capacitor
+
+Start with 2.2-4.7 uF after D2/R1, plus 100 nF ceramic close to U1.
+
+Voltage rating should leave comfortable margin below the TVS clamp. A 100 V ceramic is attractive electrically, but DC-bias derating must be checked for the selected package. Film or electrolytic parts are alternatives if the ceramic becomes impractical.
+
+### U1: 3.3 V regulator
+
+Current choice: **TPS7A1633A-Q1 / TPS7A16A-Q1 family**.
+
+Reasons:
+
+- 3-60 V input range
+- 5 uA typical quiescent current
+- 100 mA output capability
+- automotive-qualified version
+- fixed 3.3 V option
+- minimum 2.2 uF output capacitance
+
+The older TPS7A16-Q1 is also suitable; the A revision is the preferred starting point for a new design.
+
+Use at least 4.7 uF on the 3.3 V output, plus local 100 nF decoupling at every IC. We may increase the bulk value after measuring the nRF52840 advertisement burst on the real board.
+
+Do not use the power-good pullup unless firmware needs it. Any pullup becomes part of the parked-current budget.
+
+## Sheet 2: shared digital-input reference
+
+Four automotive inputs use two TLV3702-Q1 dual nanopower comparators.
+
+The comparators run from 3.3 V. Each channel consumes roughly 0.56 uA typical, so all four channels cost about 2.2 uA before the external divider current.
+
+Create one filtered reference for all four channels:
+
+```text
+3V3 ---- RREF1 3.9M ----+---- VREF_IN ~= 0.67 V
+                         |
+                    RREF2 1.0M
+                         |
+                        GND
+
+VREF_IN ---- CREF 100 nF ---- GND
+```
+
+Nominal reference:
+
+```text
+3.3 V * 1.0M / (3.9M + 1.0M) ~= 0.673 V
+```
+
+Divider current is about 0.67 uA.
+
+The threshold intentionally follows the 3.3 V rail. Absolute threshold precision is not important; we need a clean distinction between an inactive automotive line and a real 12 V state.
+
+## Sheet 3: protected automotive digital input
+
+Use the same circuit for ignition, door/courtesy, parking lights, and AUX.
+
+### First-pass channel
+
+```text
+VEH_IN ---- RIN1 11M ---- RIN2 11M ----+---- VIN_SENSE ----> Ux non-inverting input
+                                        |
+                                      RBOT 3.3M
+                                        |
+                                       GND
+
+VIN_SENSE ---- CFILT 4.7 nF ---- GND
+
+Ux inverting input -------------------- VREF_IN
+
+Ux output ----------------------------- MCU GPIO/SENSE
+      |
+      +---- RHYS 68M ------------------ VIN_SENSE
+```
+
+Add low-leakage clamps at `VIN_SENSE` to ground and 3.3 V. BAV199-Q-family diodes are a candidate because leakage matters when the divider itself only carries fractions of a microamp.
+
+### Why split the upper resistor
+
+Two 11 M resistors share transient voltage and make resistor working-voltage limits easier to satisfy. The final footprint and resistor series must still be checked for rated working voltage and pulse behavior.
+
+### Input current
+
+Ignoring hysteresis current, the main divider is 22 M + 3.3 M.
+
+At 12.6 V:
+
+```text
+12.6 V / 25.3 M ~= 0.50 uA
+```
+
+At 14.4 V:
+
+```text
+14.4 V / 25.3 M ~= 0.57 uA
+```
+
+This is acceptable even if an input stays high for months.
+
+### Threshold and hysteresis
+
+With a nominal 0.673 V reference, 22 M upper resistance, 3.3 M lower resistance, and 68 M positive-feedback resistor, the rough switching points are:
+
+- rising threshold: about 5.4 V vehicle-side
+- falling threshold: about 4.3 V vehicle-side
+
+These are hand-analysis values. Before freezing them, run the circuit through SPICE with comparator offset, resistor tolerance, clamp leakage, supply tolerance, and temperature corners.
+
+The point is not a precision 5 V detector. The point is to ignore ground noise and leakage while recognizing a real automotive high state.
+
+### Filtering
+
+The input divider has a multi-megaohm Thevenin resistance, so even 4.7 nF produces a useful millisecond-scale filter. That is desirable for old switches, relay noise, and ignition hash.
+
+Do not make the capacitor large until we simulate wake latency. Door, ignition, and light-state changes do not need microsecond response, but they should feel immediate in Home Assistant.
+
+### MCU wake behavior
+
+Each comparator output goes to an nRF52840 GPIO that supports low-power `SENSE` wake.
+
+Firmware re-arms the opposite level before sleeping:
+
+```text
+current input low  -> arm SENSE high
+current input high -> arm SENSE low
+```
+
+That gives wake-on-change behavior without leaving a higher-current peripheral running.
+
+## Sheet 4: battery-voltage ADC
+
+The battery ADC can remain permanently connected if the divider current stays near 2 uA.
+
+### Proposed network
+
+```text
+RAW_BAT ---- RBAT1 3.32M ---- RBAT2 3.32M ----+---- VBAT_ADC ---- MCU SAADC
+                                               |
+                                           RBAT3 806k
+                                               |
+                                              GND
+
+VBAT_ADC ---- CBAT 10 nF ---- GND
+```
+
+Add low-leakage clamps from `VBAT_ADC` to ground and 3.3 V.
+
+Nominal divider ratio:
+
+```text
+806k / (3.32M + 3.32M + 806k) ~= 0.1082
+```
+
+Representative values:
+
+| Raw battery | ADC node |
+| ---: | ---: |
+| 12.0 V | 1.30 V |
+| 12.8 V | 1.39 V |
+| 14.4 V | 1.56 V |
+| 20.0 V | 2.16 V |
+| 30.0 V | 3.25 V |
+
+Divider current at 12.6 V is about 1.69 uA.
+
+The source resistance seen by the ADC is roughly 720 kohms. This is intentionally near, but below, the nRF52840 SAADC source-resistance limit when the longest acquisition time is selected. Re-check this against the exact Nordic specification before creating the KiCad schematic.
+
+CBAT also acts as a charge reservoir during ADC acquisition and filters ignition noise.
+
+The raw battery node is preferred over the post-diode supply node because the reported voltage should be the battery terminal voltage, not battery voltage minus the reverse-protection diode. The megaohm resistor chain limits fault current into the ADC protection network during transients or reverse polarity.
+
+Firmware will calibrate gain and offset against a DMM.
+
+## Sheet 5: temperature inputs
+
+Use switched thermistor dividers so they consume no meaningful current while asleep.
+
+### Onboard temperature
+
+```text
+TEMP_EXCITE GPIO ---- RTOP 10k ----+---- TEMP_BOARD_ADC
+                                    |
+                                  NTC 10k
+                                    |
+                                   GND
+```
+
+`TEMP_EXCITE` is driven high only while measuring and returns to high impedance afterward.
+
+Place the onboard NTC away from U1 and the nRF module so it tracks enclosure/interior temperature rather than local regulator or radio heat.
+
+### External battery temperature
+
+Duplicate the circuit with a connector for a remote 10 k NTC. Add ESD protection and a small series resistor at the connector because this wire may leave the enclosure.
+
+The exact NTC beta value should be recorded in firmware configuration rather than assumed from the nominal 10 k resistance.
+
+## Sheet 6: nRF52840 module
+
+Use a pre-certified module. Current preferred family: Raytac MDBT50Q.
+
+The schematic should expose:
+
+- 3.3 V and ground with local bulk and 100 nF decoupling
+- SWDIO
+- SWCLK
+- RESET
+- a ground reference on the programming header
+- optional serial/debug pads if GPIO allows
+- enough ADC pins for battery and both thermistors
+- five wake-capable digital inputs
+- one reserved GPIO for future remote-start output
+- at least two spare test pads/GPIOs
+
+Follow the module maker's antenna keepout exactly. Do not run copper, traces, ground pour, enclosure metal, or a wiring bundle through the antenna zone.
+
+## Sheet 7: remote-start enable switch sense
+
+The DPDT switch has two independent jobs.
+
+Pole A is a literal series disconnect in the eventual AUX-trigger wire. It is not routed through firmware.
+
+Pole B reports the same switch position to the MCU.
+
+A simple local low-current circuit is sufficient:
+
+```text
+3V3 ---- internal or external pullup ---- MCU GPIO
+                                       |
+                                  DPDT sense pole
+                                       |
+                                      GND
+```
+
+Prefer an MCU pullup if its measured sleep current is acceptable. Otherwise use a large external resistor such as 470 k-1 M.
+
+Home Assistant can then expose `remote_start_enabled`, but that state does not participate in the physical isolation function.
+
+## Sheet 8: future remote-start output
+
+Reserve the footprint and connector path now, but do not select the final driver until the Directed Electronics AUX input is characterized.
+
+Expected topology:
+
+```text
+MCU GPIO ---- gate/base network ---- protected low-side device ---- AUX TRIGGER
+                                                        |
+                                                       GND
+
+AUX TRIGGER ---- physical series enable switch ---- remote starter AUX input
+```
+
+A small logic-level N-MOSFET is likely sufficient if the AUX input is a normal low-current ground-trigger input. An optocoupler or relay remains possible if measurements show an unexpected interface.
+
+The output must default off during reset, boot, programming, brownout, and MCU power loss.
+
+## Connector plan
+
+The final connector count is not frozen, but the electrical functions are:
+
+```text
+POWER
+  BAT+
+  GND
+
+VEHICLE INPUTS
+  IGN
+  DOOR
+  PARK_LIGHTS
+  AUX_IN
+
+TEMPERATURE
+  EXT_NTC
+  EXT_NTC_RETURN
+
+REMOTE START
+  AUX_TRIGGER_OUT
+  AUX_TRIGGER_RETURN/GND as required
+  ENABLE_SWITCH_SENSE
+```
+
+It may make mechanical sense to combine power and vehicle inputs into one locking connector and keep temperature/remote-start functions separate.
+
+## Grounding and layout rules
+
+Treat the harness entry as a noisy zone.
+
+- TVS return goes directly to the connector-side ground region.
+- Keep high-current TVS pulse paths away from MCU and ADC ground routing.
+- Route the battery ADC divider away from the antenna and digital edges.
+- Put comparator RC components close to the comparators.
+- Put LDO input/output capacitors against U1 pins.
+- Keep SWD and other test pads out of the antenna keepout.
+- Provide test points for RAW_BAT, protected VIN, 3V3, VREF_IN, VBAT_ADC, and every comparator output.
+
+A two-layer board is probably sufficient electrically, but four layers may make the RF keepout, ground return, and compact enclosure easier. Do not decide layer count until the module footprint and connector placement are known.
+
+## Bench tests before vehicle installation
+
+At minimum, verify:
+
+1. parked current at 12.6 V with all vehicle inputs low
+2. parked current with each input high, one at a time and all together
+3. current and rail droop during BLE advertisements
+4. battery ADC accuracy from roughly 6-16 V
+5. ADC behavior during rapid input noise
+6. comparator switching thresholds and hysteresis over the useful supply range
+7. wake on both input transitions
+8. reverse battery
+9. brownout/cold-cranking-style input dips
+10. elevated DC input and jump-start-like voltage
+11. positive and negative transient testing within available safe test-equipment limits
+
+Only after those tests should the prototype go into the Chevelle.
+
+## Parts currently worth carrying into KiCad
+
+| Ref | Candidate | Status |
+| --- | --- | --- |
+| U1 | TPS7A1633A-Q1 / TPS7A16A-Q1 | strong candidate |
+| U2/U3 | TLV3702-Q1 | strong candidate |
+| U4 | Raytac MDBT50Q nRF52840 module | family selected, exact variant TBD |
+| D1 | 30 V bidirectional automotive load-dump TVS | exact part TBD |
+| D2 | STTH1R02-Y-class high-voltage automotive diode | candidate |
+| ADC clamps | BAV199-Q family | candidate |
+| NTCs | 10 k automotive/industrial NTC | value selected, exact part TBD |
+
+## Next schematic decision
+
+The highest-value unresolved item is D1. Once the exact load-dump TVS is chosen, verify its worst-case clamp voltage against U1 and then freeze the battery-input sheet.
+
+After that, simulate one TLV3702-Q1 input channel over tolerances. If the threshold and leakage behavior look good, replicate it for ignition, door, parking lights, and AUX and begin the actual KiCad project.

--- a/battery_monitor/hardware/VALIDATION.md
+++ b/battery_monitor/hardware/VALIDATION.md
@@ -1,0 +1,46 @@
+# Hardware validation status
+
+The files in this directory are an early prototype schematic, not a released board design.
+
+## Checks completed
+
+The schematic generator currently verifies:
+
+- balanced KiCad S-expression syntax
+- deterministic UUID generation
+- stable output: two consecutive generator runs produce byte-for-byte identical project and schematic files
+- unique schematic reference designators
+- no generated zero-length wires
+- expected counts of symbols, wires, and net labels
+
+The current generated-file hashes are:
+
+```text
+battery_monitor.kicad_sch  a57e26d75e7c7469461b7d2926ae4e945eefa7c119d1b735781165c405217daa
+battery_monitor.kicad_pro  3319749b7ba1d4b7eb5cc83aed310ab91bf45f98b87fe2468c770c821f109be7
+```
+
+These hashes are useful only as a regression check for this revision. Saving the project in KiCad will legitimately rewrite metadata and change them.
+
+## Checks still required
+
+This environment does not currently have a working KiCad installation, so the generated schematic has **not** yet been opened by Eeschema or checked with `kicad-cli sch erc`.
+
+Before PCB layout, open the project in the current KiCad release and:
+
+1. confirm every custom symbol renders correctly
+2. verify the logical Raytac module pin assignments against the selected module datasheet
+3. replace the logical Raytac symbol with a complete production symbol/footprint
+4. run ERC and review every warning rather than blanket-excluding errors
+5. verify every assigned footprint against the actual manufacturer package
+6. check resistor working-voltage and pulse ratings
+7. check capacitor voltage derating
+8. verify BAV199-Q orientation and pin mapping
+9. review all connector pin numbers against the chosen connector family
+10. save the project in KiCad and commit the normalized files
+
+## Bench validation required before vehicle installation
+
+The schematic calculations do not establish automotive qualification. The assembled prototype still needs the electrical tests in `FRONT_END_ANALYSIS.md`, including sleep current, threshold measurements, reverse polarity, brownout, elevated DC input, and safe transient testing.
+
+The key acceptance criterion remains measured battery-side parked current below 25 uA in the defined normal parked state, with 20 uA or less preferred.

--- a/battery_monitor/hardware/battery_monitor.kicad_pro
+++ b/battery_monitor/hardware/battery_monitor.kicad_pro
@@ -1,0 +1,92 @@
+{
+  "board": {
+    "3dviewports": [],
+    "design_settings": {
+      "defaults": {},
+      "diff_pair_dimensions": [],
+      "drc_exclusions": [],
+      "rules": {},
+      "track_widths": [],
+      "via_dimensions": []
+    },
+    "layer_presets": [],
+    "viewports": []
+  },
+  "boards": [],
+  "cvpcb": {
+    "equivalence_files": []
+  },
+  "erc": {
+    "erc_exclusions": [],
+    "meta": {
+      "version": 0
+    },
+    "pin_map": []
+  },
+  "libraries": {
+    "pinned_footprint_libs": [],
+    "pinned_symbol_libs": []
+  },
+  "meta": {
+    "filename": "battery_monitor.kicad_pro",
+    "version": 2
+  },
+  "net_settings": {
+    "classes": [
+      {
+        "bus_width": 12,
+        "clearance": 0.2,
+        "diff_pair_gap": 0.25,
+        "diff_pair_via_gap": 0.25,
+        "diff_pair_width": 0.2,
+        "line_style": 0,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.1,
+        "name": "Default",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.25,
+        "via_diameter": 0.8,
+        "via_drill": 0.4,
+        "wire_width": 6
+      }
+    ],
+    "meta": {
+      "version": 3
+    },
+    "net_colors": null,
+    "netclass_assignments": null
+  },
+  "pcbnew": {
+    "last_paths": {},
+    "page_layout_descr_file": ""
+  },
+  "schematic": {
+    "annotate_start_num": 0,
+    "drawing": {
+      "dashed_lines_dash_length_ratio": 12.0,
+      "dashed_lines_gap_length_ratio": 3.0,
+      "default_line_thickness": 6.0,
+      "default_text_size": 50.0,
+      "field_names": [],
+      "intersheets_ref_own_page": false,
+      "intersheets_ref_prefix": "",
+      "intersheets_ref_short": false,
+      "intersheets_ref_show": false,
+      "intersheets_ref_suffix": "",
+      "junction_size_choice": 3,
+      "label_size_ratio": 0.375,
+      "operating_point_overlay_i_precision": 3,
+      "operating_point_overlay_i_range": "~A",
+      "operating_point_overlay_v_precision": 3,
+      "operating_point_overlay_v_range": "~V",
+      "overbar_offset_ratio": 1.23,
+      "pin_symbol_size": 25.0,
+      "text_offset_ratio": 0.15
+    },
+    "legacy_lib_dir": "",
+    "legacy_lib_list": []
+  },
+  "sheets": [],
+  "text_variables": {}
+}

--- a/battery_monitor/hardware/tools/generate_schematic.py
+++ b/battery_monitor/hardware/tools/generate_schematic.py
@@ -1,0 +1,196 @@
+import uuid, json, re
+from pathlib import Path
+
+NAMESPACE = uuid.UUID("bfc8b306-f086-4c8b-9324-f10957ddf937")
+_counter = 0
+def u():
+    global _counter
+    _counter += 1
+    return str(uuid.uuid5(NAMESPACE, f"battery-monitor-{_counter}"))
+ROOT = u()
+
+def eff(size=1.27, hide=False, justify=None):
+    s=f'(effects (font (size {size} {size}))'
+    if justify: s+=f' (justify {justify})'
+    if hide: s+=' hide'
+    return s+')'
+
+def prop(k,v,x,y,rot=0,hide=False):
+    return f'(property "{k}" "{v}" (at {x} {y} {rot}) {eff(1.0 if not hide else 0.8, hide)})'
+
+def pin_def(ptype,num,name,x,y,ang):
+    return f'(pin {ptype} line (at {x} {y} {ang}) (length 2.54) (name "{name}" {eff(0.8)}) (number "{num}" {eff(0.8)}))'
+
+def libsym(name,ref,pins,w=10,h=8,desc=''):
+    lines=[f'(symbol "BM:{name}"','  (pin_names (offset 0.8))','  (in_bom yes)','  (on_board yes)',
+           f'  {prop("Reference",ref,0,h/2+2)}',f'  {prop("Value",name,0,-h/2-2)}',
+           f'  {prop("Footprint","",0,0,hide=True)}',f'  {prop("Datasheet","",0,0,hide=True)}',f'  {prop("Description",desc,0,0,hide=True)}',
+           f'  (symbol "{name}_0_1" (rectangle (start {-w/2} {-h/2}) (end {w/2} {h/2}) (stroke (width 0.254) (type default)) (fill (type background))))',
+           f'  (symbol "{name}_1_1"']
+    for p in pins:
+        lines.append('    '+pin_def(*p))
+    lines+=['  )',')']
+    return '\n'.join(lines)
+
+LIBS=[]
+LIBS.append(libsym('R','R',[('passive','1','1',-5,0,0),('passive','2','2',5,0,180)],w=5,h=2,desc='Resistor'))
+LIBS.append(libsym('C','C',[('passive','1','1',0,-5,90),('passive','2','2',0,5,270)],w=4,h=3,desc='Capacitor'))
+LIBS.append(libsym('DIODE','D',[('passive','1','A',-5,0,0),('passive','2','K',5,0,180)],w=5,h=3,desc='Diode'))
+LIBS.append(libsym('TVS','D',[('passive','1','1',0,-5,90),('passive','2','2',0,5,270)],w=5,h=4,desc='Bidirectional TVS'))
+LIBS.append(libsym('CLAMP3','D',[('passive','1','GND clamp',0,6,270),('passive','3','SENSE',-6,0,0),('passive','2','3V3 clamp',0,-6,90)],w=6,h=6,desc='BAV199-Q series dual diode used as rail clamp'))
+LIBS.append(libsym('NTC','RT',[('passive','1','1',0,-5,90),('passive','2','2',0,5,270)],w=5,h=3,desc='NTC thermistor'))
+LIBS.append(libsym('CONN6','J',[('passive','1','BAT+',5,-6,180),('passive','2','GND',5,-3.6,180),('passive','3','IGN',5,-1.2,180),('passive','4','DOOR',5,1.2,180),('passive','5','PARK',5,3.6,180),('passive','6','AUX',5,6,180)],w=8,h=18,desc='Vehicle harness connector'))
+LIBS.append(libsym('CONN2','J',[('passive','1','1',5,-2,180),('passive','2','2',5,2,180)],w=8,h=8,desc='Two pin connector'))
+LIBS.append(libsym('LDO8','U',[('power_out','1','OUT',10,-6,180),('no_connect','2','DNC',10,-3.6,180),('open_collector','3','PG',10,-1.2,180),('power_in','4','GND',0,9,270),('input','5','EN',-10,6,0),('no_connect','6','NC',10,3.6,180),('output','7','DELAY',10,6,180),('power_in','8','IN',-10,-6,0),('power_in','9','EP',0,12,270)],w=14,h=18,desc='TPS7A1633A-Q1 fixed 3.3 V LDO; pin 9 represents exposed pad'))
+LIBS.append(libsym('COMP4','U',[
+    ('output','1','OUT_A',12,-9,180),('input','2','-IN_A',-12,-10.5,0),('input','3','+IN_A',-12,-7.5,0),('power_in','4','VCC',0,-15,90),
+    ('input','5','+IN_B',-12,-2.5,0),('input','6','-IN_B',-12,-5.5,0),('output','7','OUT_B',12,-4,180),
+    ('output','8','OUT_C',12,4,180),('input','9','-IN_C',-12,5.5,0),('input','10','+IN_C',-12,2.5,0),('power_in','11','VEE',0,15,270),
+    ('input','12','+IN_D',-12,7.5,0),('input','13','-IN_D',-12,10.5,0),('output','14','OUT_D',12,9,180)],w=18,h=26,desc='TLV7034-Q1 quad nanopower push-pull comparator, TSSOP-14'))
+LIBS.append(libsym('MCU','U',[
+    ('power_in','28','VDD',0,-22,90),('power_in','G','GND',0,22,270),
+    ('input','22','P0.06 IGN',-16,-15,0),('input','23','P0.07 DOOR',-16,-11,0),('input','24','P0.08 PARK',-16,-7,0),('input','27','P0.11 AUX',-16,-3,0),
+    ('input','11','P0.02/AIN0 VBAT',-16,3,0),('input','9','P0.03/AIN1 TEMP_BOARD',-16,7,0),('input','20','P0.04/AIN2 TEMP_EXT',-16,11,0),('input','29','P0.12 REMOTE_EN',-16,15,0),
+    ('output','36','P0.14 TEMP_B_EXC',16,3,180),('output','39','P0.15 TEMP_E_EXC',16,7,180),('output','37','P0.13 REMOTE_OUT',16,11,180),
+    ('bidirectional','51','SWDIO',16,-11,180),('input','53','SWDCLK',16,-15,180),('input','40','nRESET/P0.18',16,-7,180),
+    ('passive','17','XL1/P0.00',16,15,180),('passive','18','XL2/P0.01',16,19,180)],w=26,h=40,desc='Logical symbol for Raytac MDBT50Q-1MV2; complete 61-pad PCB symbol/footprint still to be created from Raytac drawing'))
+
+symbols=[]; wires=[]; labels=[]; ncs=[]; texts=[]
+
+def inst(lib,ref,val,x,y,foot='',datasheet='',desc='',dnp='no'):
+    sid=u()
+    ls=next(s for s in LIBS if s.startswith(f'(symbol "BM:{lib}"'))
+    nums=re.findall(r'\(number "([^"]+)"',ls)
+    plist=[prop('Reference',ref,x,y-5),prop('Value',val,x,y+5),prop('Footprint',foot,x,y,hide=True),prop('Datasheet',datasheet,x,y,hide=True),prop('Description',desc,x,y,hide=True)]
+    sl=[f'(symbol (lib_id "BM:{lib}") (at {x} {y} 0) (unit 1) (in_bom yes) (on_board yes) (uuid {sid})']
+    sl += ['  '+p for p in plist]
+    for num in nums: sl.append(f'  (pin "{num}" (uuid {u()}))')
+    sl.append(f'  (instances (project "battery_monitor" (path "/{ROOT}" (reference "{ref}") (unit 1))))')
+    sl.append(')')
+    symbols.append('\n'.join(sl)); return sid
+
+def wire(x1,y1,x2,y2): wires.append(f'(wire (pts (xy {x1} {y1}) (xy {x2} {y2})) (stroke (width 0) (type default)) (uuid {u()}))')
+def label(name,x,y,rot=0): labels.append(f'(label "{name}" (at {x} {y} {rot}) {eff(1.0)} (uuid {u()}))')
+def nc(x,y): ncs.append(f'(no_connect (at {x} {y}) (uuid {u()}))')
+def text(s,x,y,size=1.27): texts.append(f'(text "{s}" (at {x} {y} 0) {eff(size)} (uuid {u()}))')
+
+inst('CONN6','J1','VEHICLE',20,110,desc='BAT+, ground, ignition, door/courtesy, parking lights, spare input')
+for name,yy in [('RAW_BAT',104),('GND',106.4),('VEH_IGN',108.8),('VEH_DOOR',111.2),('VEH_PARK',113.6),('VEH_AUX',116)]:
+    wire(25,yy,31,yy); label(name,31,yy)
+
+text('POWER / AUTOMOTIVE PROTECTION',20,20,1.6)
+label('RAW_BAT',20,30); wire(20,30,28,30)
+inst('TVS','D1','SM50T30CAY',28,42,'Diode_SMD:D_SMC','https://www.st.com/','5 kW bidirectional automotive TVS')
+wire(28,37,28,30); wire(28,47,28,52); label('GND',28,52)
+inst('DIODE','D2','STTH1R02-Y',42,30,'Diode_SMD:D_SOD-123F','https://www.st.com/','200 V automotive reverse-battery diode')
+wire(28,30,37,30)
+inst('R','R1','100R 1W',55,30,'Resistor_SMD:R_2512_6332Metric','','Supply isolation / pulse limiting')
+wire(47,30,50,30); wire(60,30,66,30); label('VIN_PROTECTED',66,30)
+inst('C','C1','4.7u 100V',66,42,'Capacitor_SMD:C_1210_3225Metric','','Protected input bulk capacitor'); wire(66,37,66,30); wire(66,47,66,52); label('GND',66,52)
+inst('C','C2','100n 100V',74,42,'Capacitor_SMD:C_0805_2012Metric','','LDO input HF bypass'); wire(74,37,74,30); wire(74,47,74,52); label('GND',74,52)
+inst('LDO8','U1','TPS7A1633AQDGNRQ1',92,36,'','https://www.ti.com/product/TPS7A16A-Q1','60 V 5 uA IQ fixed 3.3 V automotive LDO')
+wire(82,30,74,30); wire(82,42,78,42); label('VIN_PROTECTED',78,42)
+wire(102,30,110,30); label('3V3',110,30)
+wire(92,45,92,52); label('GND',92,52); wire(92,48,92,52)
+for yy in [32.4,34.8,39.6,42]: nc(102,yy)
+inst('C','C3','10u 10V',112,42,'Capacitor_SMD:C_1206_3216Metric','','3.3 V bulk'); wire(112,37,112,30); wire(112,47,112,52); label('GND',112,52)
+inst('C','C4','100n',120,42,'Capacitor_SMD:C_0805_2012Metric','','3.3 V HF bypass'); wire(120,37,120,30); wire(120,47,120,52); label('GND',120,52)
+
+text('WAKE INPUT REFERENCE',130,20,1.4)
+inst('R','R2','3.9M 1%',138,30,'Resistor_SMD:R_0805_2012Metric'); label('3V3',128,30); wire(128,30,133,30)
+inst('R','R3','1.0M 1%',151,30,'Resistor_SMD:R_0805_2012Metric'); wire(143,30,146,30); wire(156,30,162,30); label('GND',162,30); label('VREF_WAKE',145,30)
+inst('C','C5','100n',145,42,'Capacitor_SMD:C_0805_2012Metric'); wire(145,37,145,30); wire(145,47,145,52); label('GND',145,52)
+
+inst('COMP4','U2','TLV7034QPWRQ1',170,112,'Package_SO:TSSOP-14_4.4x5mm_P0.65mm','https://www.ti.com/product/TLV7034-Q1','Quad nanopower automotive comparator')
+wire(170,97,170,91); label('3V3',170,91); wire(170,127,170,133); label('GND',170,133)
+for yy in [101.5,106.5,117.5,122.5]: wire(158,yy,153,yy); label('VREF_WAKE',153,yy)
+
+rows=[('IGN',72,104.5,103),('DOOR',92,109.5,108),('PARK',112,114.5,116),('AUX',132,119.5,121)]
+for idx,(name,row,plusy,outy) in enumerate(rows, start=1):
+    y=row
+    label('VEH_'+name,34,y); wire(34,y,40,y)
+    inst('R',f'R{10+(idx-1)*4}', '4.7M 1%',45,y,'Resistor_SMD:R_1206_3216Metric')
+    inst('R',f'R{11+(idx-1)*4}', '4.7M 1%',58,y,'Resistor_SMD:R_1206_3216Metric')
+    wire(34,y,40,y); wire(50,y,53,y); wire(63,y,70,y); label(f'{name}_SENSE',70,y)
+    inst('R',f'R{12+(idx-1)*4}','1.5M 1%',76,y+7,'Resistor_SMD:R_1206_3216Metric')
+    label(f'{name}_SENSE',146,plusy); wire(146,plusy,158,plusy)
+    label(f'{name}_SENSE',70,y+7); wire(70,y+7,71,y+7); wire(81,y+7,86,y+7); label('GND',86,y+7)
+    inst('C',f'C{10+idx}', '4.7n',92,y+7,'Capacitor_SMD:C_0805_2012Metric'); wire(92,y+2,92,y+1); label(f'{name}_SENSE',92,y+1); wire(92,y+12,92,y+13); label('GND',92,y+13)
+    inst('CLAMP3',f'D{2+idx}','BAV199-Q',108,y+7,'Package_TO_SOT_SMD:SOT-23','https://www.nexperia.com/product/BAV199-Q','Low leakage rail clamp'); wire(102,y+7,98,y+7); label(f'{name}_SENSE',98,y+7); wire(108,y+1,108,y); label('3V3',108,y); wire(108,y+13,108,y+14); label('GND',108,y+14)
+    wire(182,outy,190,outy); label(f'{name}_WAKE',190,outy)
+    inst('R',f'R{13+(idx-1)*4}','33M 1%',128,y+7,'Resistor_SMD:R_1206_3216Metric')
+    label(f'{name}_WAKE',123,y+7); wire(133,y+7,139,y+7); label(f'{name}_SENSE',139,y+7)
+
+wires=[w for w in wires if not re.search(r'\(xy ([\d.]+) ([\d.]+)\) \(xy \1 \2\)',w)]
+
+text('BATTERY ADC',20,150,1.4)
+label('RAW_BAT',20,160); wire(20,160,25,160)
+inst('R','R30','3.32M 1%',30,160,'Resistor_SMD:R_1206_3216Metric'); inst('R','R31','3.32M 1%',43,160,'Resistor_SMD:R_1206_3216Metric'); wire(35,160,38,160); wire(48,160,55,160); label('VBAT_ADC',55,160)
+inst('R','R32','806k 1%',62,168,'Resistor_SMD:R_1206_3216Metric'); label('VBAT_ADC',57,168); wire(67,168,72,168); label('GND',72,168)
+inst('C','C20','10n',80,168,'Capacitor_SMD:C_0805_2012Metric'); wire(80,163,80,160); label('VBAT_ADC',80,160); wire(80,173,80,176); label('GND',80,176)
+inst('CLAMP3','D7','BAV199-Q',94,168,'Package_TO_SOT_SMD:SOT-23'); wire(88,168,84,168); label('VBAT_ADC',84,168); wire(94,162,94,160); label('3V3',94,160); wire(94,174,94,176); label('GND',94,176)
+
+text('MCU / BLE',205,20,1.4)
+inst('MCU','U3','MDBT50Q-1MV2 (logical symbol)',225,110,'','https://www.raytac.com/','nRF52840 module; full 61-pad symbol and footprint still TBD')
+wire(225,88,225,82); label('3V3',225,82); wire(225,132,225,138); label('GND',225,138)
+for net,yy in [('IGN_WAKE',95),('DOOR_WAKE',99),('PARK_WAKE',103),('AUX_WAKE',107),('VBAT_ADC',113),('TEMP_BOARD_ADC',117),('TEMP_EXT_ADC',121),('REMOTE_ENABLE',125)]:
+    wire(209,yy,203,yy); label(net,203,yy)
+for net,yy in [('TEMP_BOARD_EXCITE',113),('TEMP_EXT_EXCITE',117),('REMOTE_START_OUT_DNP',121),('SWDIO',99),('SWDCLK',95),('RESET_N',103),('XL1',125),('XL2',129)]:
+    wire(241,yy,247,yy); label(net,247,yy)
+
+text('TEMPERATURE',120,150,1.4)
+label('TEMP_BOARD_EXCITE',120,160); wire(120,160,125,160); inst('R','R40','10k 1%',130,160,'Resistor_SMD:R_0805_2012Metric'); wire(135,160,140,160); label('TEMP_BOARD_ADC',140,160)
+inst('NTC','RT1','10k NTC TBD',150,168,'Resistor_SMD:R_0805_2012Metric'); wire(150,163,150,160); label('TEMP_BOARD_ADC',150,160); wire(150,173,150,176); label('GND',150,176)
+label('TEMP_EXT_EXCITE',165,160); wire(165,160,170,160); inst('R','R41','10k 1%',175,160,'Resistor_SMD:R_0805_2012Metric'); wire(180,160,185,160); label('TEMP_EXT_ADC',185,160)
+inst('CONN2','J2','EXT_NTC',195,168,desc='Remote battery thermistor connector'); wire(200,166,205,166); label('TEMP_EXT_ADC',205,166); wire(200,170,205,170); label('GND',205,170)
+
+text('REMOTE START PROVISION',215,150,1.4)
+label('3V3',215,160); wire(215,160,220,160); inst('R','R42','4.7M',225,160,'Resistor_SMD:R_0805_2012Metric'); wire(230,160,235,160); label('REMOTE_ENABLE',235,160)
+inst('CONN2','J3','DPDT_SENSE_POLE',245,168,desc='Second pole of physical remote-start disable switch'); wire(250,166,255,166); label('REMOTE_ENABLE',255,166); wire(250,170,255,170); label('GND',255,170)
+text('Future REMOTE_START_OUT driver intentionally DNP / not designed yet',215,180,1.0)
+
+text('Prototype schematic: input/power values frozen for first build; full Raytac footprint, connectors, remote-start driver, and PCB layout remain open.',20,194,1.0)
+text('Generated KiCad source; open/save in KiCad 10 and run ERC before PCB layout.',20,199,1.0)
+
+schematic=['(kicad_sch','  (version 20231120)','  (generator "battery_monitor_generator")',f'  (uuid {ROOT})','  (paper "A3")','  (title_block (title "Low-power BLE battery monitor") (date "2026-08-16") (rev "0.1") (comment 1 "Prototype power, sensing, and wake-input schematic"))','  (lib_symbols']
+for ls in LIBS: schematic.append('\n'.join('    '+ln for ln in ls.splitlines()))
+schematic.append('  )')
+for seq in [texts,wires,ncs,labels,symbols]:
+    for item in seq: schematic.append('  '+item.replace('\n','\n  '))
+schematic.append(f'  (sheet_instances (path "/" (page "1")))')
+schematic.append(')')
+textout='\n'.join(schematic)+'\n'
+OUT_DIR = Path(__file__).resolve().parents[1]
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+Path(OUT_DIR / 'battery_monitor.kicad_sch').write_text(textout)
+
+pro={
+  'board': {'3dviewports': [], 'design_settings': {'defaults': {}, 'diff_pair_dimensions': [], 'drc_exclusions': [], 'rules': {}, 'track_widths': [], 'via_dimensions': []}, 'layer_presets': [], 'viewports': []},
+  'boards': [], 'cvpcb': {'equivalence_files': []},
+  'erc': {'erc_exclusions': [], 'meta': {'version': 0}, 'pin_map': []},
+  'libraries': {'pinned_footprint_libs': [], 'pinned_symbol_libs': []},
+  'meta': {'filename': 'battery_monitor.kicad_pro', 'version': 2},
+  'net_settings': {'classes': [{'bus_width': 12, 'clearance': 0.2, 'diff_pair_gap': 0.25, 'diff_pair_via_gap': 0.25, 'diff_pair_width': 0.2, 'line_style': 0, 'microvia_diameter': 0.3, 'microvia_drill': 0.1, 'name': 'Default', 'pcb_color': 'rgba(0, 0, 0, 0.000)', 'schematic_color': 'rgba(0, 0, 0, 0.000)', 'track_width': 0.25, 'via_diameter': 0.8, 'via_drill': 0.4, 'wire_width': 6}], 'meta': {'version': 3}, 'net_colors': None, 'netclass_assignments': None},
+  'pcbnew': {'last_paths': {}, 'page_layout_descr_file': ''},
+  'schematic': {'annotate_start_num': 0, 'drawing': {'dashed_lines_dash_length_ratio': 12.0, 'dashed_lines_gap_length_ratio': 3.0, 'default_line_thickness': 6.0, 'default_text_size': 50.0, 'field_names': [], 'intersheets_ref_own_page': False, 'intersheets_ref_prefix': '', 'intersheets_ref_short': False, 'intersheets_ref_show': False, 'intersheets_ref_suffix': '', 'junction_size_choice': 3, 'label_size_ratio': 0.375, 'operating_point_overlay_i_precision': 3, 'operating_point_overlay_i_range': '~A', 'operating_point_overlay_v_precision': 3, 'operating_point_overlay_v_range': '~V', 'overbar_offset_ratio': 1.23, 'pin_symbol_size': 25.0, 'text_offset_ratio': 0.15}, 'legacy_lib_dir': '', 'legacy_lib_list': []},
+  'sheets': [], 'text_variables': {}
+}
+Path(OUT_DIR / 'battery_monitor.kicad_pro').write_text(json.dumps(pro, indent=2, sort_keys=True)+'\n')
+
+s=textout
+stack=[]; inq=False; esc=False
+for i,ch in enumerate(s):
+    if inq:
+        if esc: esc=False
+        elif ch=='\\': esc=True
+        elif ch=='"': inq=False
+    else:
+        if ch=='"': inq=True
+        elif ch=='(': stack.append(i)
+        elif ch==')':
+            if not stack: raise SystemExit(f'extra ) at {i}')
+            stack.pop()
+if inq or stack: raise SystemExit(f'parse issue quote={inq} stack={len(stack)}')
+print('root',ROOT)
+print('schematic bytes',len(textout.encode()),'lines',len(textout.splitlines()),'symbols',len(symbols),'wires',len(wires),'labels',len(labels))
+print('balanced s-expression: yes')


### PR DESCRIPTION
## What changed

Adds `battery_monitor/DESIGN.md` to capture the current requirements and design decisions for the low-power BLE battery monitor.

The document records:

- the sub-25 uA parked-current target
- adaptive reporting and low-battery self-preservation behavior
- Home Assistant versus firmware responsibilities
- required ignition, door, parking-light, spare, temperature, and remote-start-enable inputs
- the planned future ground-trigger remote-start output
- the current nRF52840/BTHome direction
- the proposed automotive power and comparator-input architecture
- a work order for the schematic
- the intended future KiCad, firmware, and OpenSCAD repository layout

## Why

The design has enough interacting electrical, firmware, and Home Assistant decisions that keeping them only in chat would make later schematic and PCB iterations difficult to review. This gives us a durable source of truth and a branch we can update as measurements change assumptions.

## Validation

Documentation-only change. Part choices and numerical targets are explicitly marked provisional until datasheet review and bench testing.
